### PR TITLE
[Phase 3] ファストファッション商品提案 — 楽天API連携・不足アイテム検出・商品カードUI

### DIFF
--- a/apps/api/drizzle/0000_nappy_firelord.sql
+++ b/apps/api/drizzle/0000_nappy_firelord.sql
@@ -1,0 +1,96 @@
+CREATE TABLE "clothing_items" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"image_url" text NOT NULL,
+	"thumbnail_url" text,
+	"category" varchar(50) DEFAULT 'other' NOT NULL,
+	"colors" jsonb DEFAULT '[]'::jsonb,
+	"tags" jsonb DEFAULT '[]'::jsonb,
+	"brand" varchar(100),
+	"embedding" jsonb,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "coordinate_jobs" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"inspiration_id" uuid NOT NULL,
+	"status" varchar(20) DEFAULT 'pending' NOT NULL,
+	"suggestions" jsonb,
+	"error_message" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "coordinates" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"inspiration_image_url" text NOT NULL,
+	"inspiration_source" varchar(50),
+	"item_ids" jsonb DEFAULT '[]'::jsonb,
+	"description" text,
+	"style_note" text,
+	"match_score" real,
+	"is_favorite" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "inspirations" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"image_url" text NOT NULL,
+	"status" varchar(20) DEFAULT 'pending' NOT NULL,
+	"analysis_data" jsonb,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "product_suggestions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"coordinate_id" uuid NOT NULL,
+	"name" text NOT NULL,
+	"brand" varchar(100),
+	"image_url" text NOT NULL,
+	"price" integer NOT NULL,
+	"product_url" text NOT NULL,
+	"category" varchar(50),
+	"source" varchar(50) NOT NULL,
+	"external_id" text,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "refresh_tokens" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"token" text NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "refresh_tokens_token_unique" UNIQUE("token")
+);
+--> statement-breakpoint
+CREATE TABLE "users" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"email" varchar(255) NOT NULL,
+	"name" varchar(100) NOT NULL,
+	"password_hash" text,
+	"avatar_url" text,
+	"provider" varchar(50) DEFAULT 'email',
+	"provider_id" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "users_email_unique" UNIQUE("email")
+);
+--> statement-breakpoint
+ALTER TABLE "clothing_items" ADD CONSTRAINT "clothing_items_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "coordinate_jobs" ADD CONSTRAINT "coordinate_jobs_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "coordinate_jobs" ADD CONSTRAINT "coordinate_jobs_inspiration_id_inspirations_id_fk" FOREIGN KEY ("inspiration_id") REFERENCES "public"."inspirations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "coordinates" ADD CONSTRAINT "coordinates_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "inspirations" ADD CONSTRAINT "inspirations_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "product_suggestions" ADD CONSTRAINT "product_suggestions_coordinate_id_coordinates_id_fk" FOREIGN KEY ("coordinate_id") REFERENCES "public"."coordinates"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "refresh_tokens" ADD CONSTRAINT "refresh_tokens_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "clothing_items_user_id_idx" ON "clothing_items" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "coordinate_jobs_user_id_idx" ON "coordinate_jobs" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "coordinates_user_id_idx" ON "coordinates" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "inspirations_user_id_idx" ON "inspirations" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "product_suggestions_coordinate_id_idx" ON "product_suggestions" USING btree ("coordinate_id");--> statement-breakpoint
+CREATE INDEX "refresh_tokens_user_id_idx" ON "refresh_tokens" USING btree ("user_id");

--- a/apps/api/drizzle/meta/0000_snapshot.json
+++ b/apps/api/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,704 @@
+{
+  "id": "6089452d-50ce-451d-ba40-7bb7ee32ded1",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.clothing_items": {
+      "name": "clothing_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "colors": {
+          "name": "colors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "brand": {
+          "name": "brand",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "clothing_items_user_id_idx": {
+          "name": "clothing_items_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clothing_items_user_id_users_id_fk": {
+          "name": "clothing_items_user_id_users_id_fk",
+          "tableFrom": "clothing_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coordinate_jobs": {
+      "name": "coordinate_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inspiration_id": {
+          "name": "inspiration_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "suggestions": {
+          "name": "suggestions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "coordinate_jobs_user_id_idx": {
+          "name": "coordinate_jobs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "coordinate_jobs_user_id_users_id_fk": {
+          "name": "coordinate_jobs_user_id_users_id_fk",
+          "tableFrom": "coordinate_jobs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "coordinate_jobs_inspiration_id_inspirations_id_fk": {
+          "name": "coordinate_jobs_inspiration_id_inspirations_id_fk",
+          "tableFrom": "coordinate_jobs",
+          "tableTo": "inspirations",
+          "columnsFrom": [
+            "inspiration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.coordinates": {
+      "name": "coordinates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inspiration_image_url": {
+          "name": "inspiration_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inspiration_source": {
+          "name": "inspiration_source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_ids": {
+          "name": "item_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "style_note": {
+          "name": "style_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_score": {
+          "name": "match_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "coordinates_user_id_idx": {
+          "name": "coordinates_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "coordinates_user_id_users_id_fk": {
+          "name": "coordinates_user_id_users_id_fk",
+          "tableFrom": "coordinates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inspirations": {
+      "name": "inspirations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "analysis_data": {
+          "name": "analysis_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "inspirations_user_id_idx": {
+          "name": "inspirations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inspirations_user_id_users_id_fk": {
+          "name": "inspirations_user_id_users_id_fk",
+          "tableFrom": "inspirations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_suggestions": {
+      "name": "product_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "coordinate_id": {
+          "name": "coordinate_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand": {
+          "name": "brand",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_url": {
+          "name": "product_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "product_suggestions_coordinate_id_idx": {
+          "name": "product_suggestions_coordinate_id_idx",
+          "columns": [
+            {
+              "expression": "coordinate_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "product_suggestions_coordinate_id_coordinates_id_fk": {
+          "name": "product_suggestions_coordinate_id_coordinates_id_fk",
+          "tableFrom": "product_suggestions",
+          "tableTo": "coordinates",
+          "columnsFrom": [
+            "coordinate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_user_id_idx": {
+          "name": "refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_unique": {
+          "name": "refresh_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'email'"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1773052858597,
+      "tag": "0000_nappy_firelord",
+      "breakpoints": true
+    }
+  ]
+}

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -17,6 +17,7 @@ export const config = {
   port: Number(optionalEnv('PORT', '3001')),
   databaseUrl: requireEnv('DATABASE_URL'),
   anthropicApiKey: process.env.ANTHROPIC_API_KEY,
+  rakutenAppId: process.env.RAKUTEN_APP_ID,
   r2: {
     accountId: process.env.CLOUDFLARE_R2_ACCOUNT_ID,
     accessKeyId: process.env.CLOUDFLARE_R2_ACCESS_KEY_ID,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config'
 import { serve } from '@hono/node-server'
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'

--- a/apps/api/src/routes/coordinate.ts
+++ b/apps/api/src/routes/coordinate.ts
@@ -123,6 +123,24 @@ coordinateRoutes.post(
   }
 )
 
+// GET /coordinates/:id — get single coordinate by id
+coordinateRoutes.get('/:id', async (c) => {
+  const { userId } = c.get('user')
+  const { id } = c.req.param()
+
+  const [coord] = await db
+    .select()
+    .from(coordinates)
+    .where(and(eq(coordinates.id, id), eq(coordinates.userId, userId)))
+    .limit(1)
+
+  if (!coord) {
+    return c.json({ error: 'Not found', code: 'NOT_FOUND', statusCode: 404 }, 404)
+  }
+
+  return c.json({ data: coord })
+})
+
 // GET /coordinates — list user's saved coordinates
 coordinateRoutes.get(
   '/',

--- a/apps/api/src/routes/product.ts
+++ b/apps/api/src/routes/product.ts
@@ -1,19 +1,112 @@
 import { Hono } from 'hono'
+import { zValidator } from '@hono/zod-validator'
+import { z } from 'zod'
 import { db } from '../db'
-import { productSuggestions } from '../db/schema'
-import { eq } from 'drizzle-orm'
+import { coordinates, clothingItems, productSuggestions } from '../db/schema'
+import { eq, and, inArray } from 'drizzle-orm'
 import { authMiddleware } from '../middleware/auth'
+import { searchProducts } from '../services/rakuten'
 
 import type { AppEnv } from '../types'
-export const productRoutes = new Hono<AppEnv>()
 
+export const productRoutes = new Hono<AppEnv>()
 productRoutes.use('*', authMiddleware)
 
-productRoutes.get('/coordinate/:coordinateId', async (c) => {
+const ALL_CATEGORIES = ['tops', 'bottoms', 'outerwear', 'shoes', 'bag', 'accessory'] as const
+type Category = typeof ALL_CATEGORIES[number]
+
+// GET /products/coordinates/:coordinateId
+// Returns missing-category product suggestions for a saved coordinate.
+// Results are cached in productSuggestions table; re-fetched on explicit refresh.
+productRoutes.get('/coordinates/:coordinateId', async (c) => {
+  const { userId } = c.get('user')
   const { coordinateId } = c.req.param()
-  const products = await db
+
+  // Verify ownership
+  const [coord] = await db
+    .select()
+    .from(coordinates)
+    .where(and(eq(coordinates.id, coordinateId), eq(coordinates.userId, userId)))
+    .limit(1)
+
+  if (!coord) {
+    return c.json({ error: 'Not found', code: 'NOT_FOUND', statusCode: 404 }, 404)
+  }
+
+  // Return cached products if available
+  const cached = await db
     .select()
     .from(productSuggestions)
     .where(eq(productSuggestions.coordinateId, coordinateId))
-  return c.json({ data: products })
+
+  if (cached.length > 0) {
+    const missingCategories = [...new Set(cached.map((p) => p.category).filter(Boolean))] as string[]
+    return c.json({ data: { missingCategories, products: cached } })
+  }
+
+  // Detect missing categories
+  const itemIds = (coord.itemIds ?? []) as string[]
+  const usedCategories = new Set<string>()
+
+  if (itemIds.length > 0) {
+    const items = await db
+      .select({ category: clothingItems.category })
+      .from(clothingItems)
+      .where(inArray(clothingItems.id, itemIds))
+    items.forEach((i) => usedCategories.add(i.category))
+  }
+
+  const missingCategories = ALL_CATEGORIES.filter(
+    (cat): cat is Category => !usedCategories.has(cat)
+  )
+
+  if (missingCategories.length === 0) {
+    return c.json({ data: { missingCategories: [], products: [] } })
+  }
+
+  // Fetch products for each missing category (in parallel, max 3 categories)
+  const targetCategories = missingCategories.slice(0, 3)
+  const results = await Promise.all(targetCategories.map((cat) => searchProducts(cat)))
+
+  // Flatten and cache in DB
+  const allProducts = results.flat()
+  if (allProducts.length > 0) {
+    await db.insert(productSuggestions).values(
+      allProducts.map((p) => ({
+        coordinateId,
+        name: p.name,
+        brand: p.brand,
+        imageUrl: p.imageUrl,
+        price: p.price,
+        productUrl: p.productUrl,
+        category: p.category,
+        source: p.source,
+        externalId: p.externalId,
+      }))
+    )
+  }
+
+  const saved = await db
+    .select()
+    .from(productSuggestions)
+    .where(eq(productSuggestions.coordinateId, coordinateId))
+
+  return c.json({ data: { missingCategories: targetCategories, products: saved } })
 })
+
+// GET /products/search?category=&keyword=&minPrice=&maxPrice=
+productRoutes.get(
+  '/search',
+  zValidator(
+    'query',
+    z.object({
+      category: z.string().optional(),
+      keyword: z.string().optional(),
+    })
+  ),
+  async (c) => {
+    const { category } = c.req.valid('query')
+    const products = await searchProducts(category ?? 'tops')
+    return c.json({ data: products })
+  }
+)

--- a/apps/api/src/routes/product.ts
+++ b/apps/api/src/routes/product.ts
@@ -40,7 +40,9 @@ productRoutes.get('/coordinates/:coordinateId', async (c) => {
     .where(eq(productSuggestions.coordinateId, coordinateId))
 
   if (cached.length > 0) {
-    const missingCategories = [...new Set(cached.map((p) => p.category).filter(Boolean))] as string[]
+    const cachedCategorySet = new Set(cached.map((p) => p.category).filter(Boolean))
+    // Preserve ALL_CATEGORIES order for consistent UI rendering
+    const missingCategories = ALL_CATEGORIES.filter((cat) => cachedCategorySet.has(cat))
     return c.json({ data: { missingCategories, products: cached } })
   }
 
@@ -94,14 +96,13 @@ productRoutes.get('/coordinates/:coordinateId', async (c) => {
   return c.json({ data: { missingCategories: targetCategories, products: saved } })
 })
 
-// GET /products/search?category=&keyword=&minPrice=&maxPrice=
+// GET /products/search?category=
 productRoutes.get(
   '/search',
   zValidator(
     'query',
     z.object({
       category: z.string().optional(),
-      keyword: z.string().optional(),
     })
   ),
   async (c) => {

--- a/apps/api/src/services/rakuten.ts
+++ b/apps/api/src/services/rakuten.ts
@@ -1,0 +1,123 @@
+import { config } from '../config'
+
+export interface RakutenProduct {
+  externalId: string
+  name: string
+  brand: string | null
+  imageUrl: string
+  price: number       // JPY
+  productUrl: string
+  category: string
+  source: 'rakuten'
+}
+
+// Map internal category names to Rakuten search keywords
+const CATEGORY_KEYWORDS: Record<string, string> = {
+  tops:      'トップス レディース',
+  bottoms:   'ボトムス スカート パンツ レディース',
+  outerwear: 'アウター コート ジャケット レディース',
+  shoes:     'シューズ スニーカー パンプス レディース',
+  bag:       'バッグ レディース',
+  accessory: 'アクセサリー レディース',
+  other:     'ファッション レディース',
+}
+
+const RAKUTEN_SEARCH_URL = 'https://app.rakuten.co.jp/services/api/IchibaItem/Search/20170706'
+const PRODUCTS_PER_CATEGORY = 4
+
+// --- Mock data for dev/test (no API key) ---
+
+const MOCK_PRODUCTS: Record<string, RakutenProduct[]> = {
+  tops: [
+    { externalId: 'mock-tops-1', name: 'オーバーサイズTシャツ', brand: 'UNIQLO', imageUrl: 'https://placehold.co/400x400/f5f5f5/888?text=Tops', price: 1990, productUrl: 'https://www.rakuten.co.jp', category: 'tops', source: 'rakuten' },
+    { externalId: 'mock-tops-2', name: 'リネンシャツ', brand: 'GU', imageUrl: 'https://placehold.co/400x400/f5f5f5/888?text=Shirt', price: 2490, productUrl: 'https://www.rakuten.co.jp', category: 'tops', source: 'rakuten' },
+    { externalId: 'mock-tops-3', name: 'ニットセーター', brand: 'Zara', imageUrl: 'https://placehold.co/400x400/f5f5f5/888?text=Knit', price: 4990, productUrl: 'https://www.rakuten.co.jp', category: 'tops', source: 'rakuten' },
+    { externalId: 'mock-tops-4', name: 'ストライプブラウス', brand: 'H&M', imageUrl: 'https://placehold.co/400x400/f5f5f5/888?text=Blouse', price: 3490, productUrl: 'https://www.rakuten.co.jp', category: 'tops', source: 'rakuten' },
+  ],
+  bottoms: [
+    { externalId: 'mock-bottoms-1', name: 'ハイウエストデニム', brand: 'LEVI\'S', imageUrl: 'https://placehold.co/400x400/e8e8ff/888?text=Denim', price: 8990, productUrl: 'https://www.rakuten.co.jp', category: 'bottoms', source: 'rakuten' },
+    { externalId: 'mock-bottoms-2', name: 'フレアスカート', brand: 'GU', imageUrl: 'https://placehold.co/400x400/e8e8ff/888?text=Skirt', price: 2990, productUrl: 'https://www.rakuten.co.jp', category: 'bottoms', source: 'rakuten' },
+    { externalId: 'mock-bottoms-3', name: 'ワイドパンツ', brand: 'UNIQLO', imageUrl: 'https://placehold.co/400x400/e8e8ff/888?text=Pants', price: 3990, productUrl: 'https://www.rakuten.co.jp', category: 'bottoms', source: 'rakuten' },
+    { externalId: 'mock-bottoms-4', name: 'プリーツスカート', brand: 'Zara', imageUrl: 'https://placehold.co/400x400/e8e8ff/888?text=Pleats', price: 5990, productUrl: 'https://www.rakuten.co.jp', category: 'bottoms', source: 'rakuten' },
+  ],
+  outerwear: [
+    { externalId: 'mock-outer-1', name: 'チェスターコート', brand: 'UNIQLO', imageUrl: 'https://placehold.co/400x400/ffe8e8/888?text=Coat', price: 12900, productUrl: 'https://www.rakuten.co.jp', category: 'outerwear', source: 'rakuten' },
+    { externalId: 'mock-outer-2', name: 'デニムジャケット', brand: 'GU', imageUrl: 'https://placehold.co/400x400/ffe8e8/888?text=Jacket', price: 4990, productUrl: 'https://www.rakuten.co.jp', category: 'outerwear', source: 'rakuten' },
+    { externalId: 'mock-outer-3', name: 'トレンチコート', brand: 'Burberry', imageUrl: 'https://placehold.co/400x400/ffe8e8/888?text=Trench', price: 45000, productUrl: 'https://www.rakuten.co.jp', category: 'outerwear', source: 'rakuten' },
+    { externalId: 'mock-outer-4', name: 'ブルゾン', brand: 'H&M', imageUrl: 'https://placehold.co/400x400/ffe8e8/888?text=Blouson', price: 6990, productUrl: 'https://www.rakuten.co.jp', category: 'outerwear', source: 'rakuten' },
+  ],
+  shoes: [
+    { externalId: 'mock-shoes-1', name: 'レザーローファー', brand: 'DIANA', imageUrl: 'https://placehold.co/400x400/e8ffe8/888?text=Loafer', price: 11000, productUrl: 'https://www.rakuten.co.jp', category: 'shoes', source: 'rakuten' },
+    { externalId: 'mock-shoes-2', name: 'ホワイトスニーカー', brand: 'adidas', imageUrl: 'https://placehold.co/400x400/e8ffe8/888?text=Sneaker', price: 9900, productUrl: 'https://www.rakuten.co.jp', category: 'shoes', source: 'rakuten' },
+    { externalId: 'mock-shoes-3', name: 'ストラップサンダル', brand: 'ZARA', imageUrl: 'https://placehold.co/400x400/e8ffe8/888?text=Sandal', price: 5990, productUrl: 'https://www.rakuten.co.jp', category: 'shoes', source: 'rakuten' },
+    { externalId: 'mock-shoes-4', name: 'アンクルブーツ', brand: 'UNITED ARROWS', imageUrl: 'https://placehold.co/400x400/e8ffe8/888?text=Boots', price: 18000, productUrl: 'https://www.rakuten.co.jp', category: 'shoes', source: 'rakuten' },
+  ],
+  bag: [
+    { externalId: 'mock-bag-1', name: 'ミニショルダーバッグ', brand: 'ZARA', imageUrl: 'https://placehold.co/400x400/fff8e8/888?text=Shoulder', price: 4990, productUrl: 'https://www.rakuten.co.jp', category: 'bag', source: 'rakuten' },
+    { externalId: 'mock-bag-2', name: 'トートバッグ', brand: 'DEAN&DELUCA', imageUrl: 'https://placehold.co/400x400/fff8e8/888?text=Tote', price: 3990, productUrl: 'https://www.rakuten.co.jp', category: 'bag', source: 'rakuten' },
+    { externalId: 'mock-bag-3', name: 'チェーンバッグ', brand: 'H&M', imageUrl: 'https://placehold.co/400x400/fff8e8/888?text=Chain', price: 6990, productUrl: 'https://www.rakuten.co.jp', category: 'bag', source: 'rakuten' },
+  ],
+  accessory: [
+    { externalId: 'mock-acc-1', name: 'ゴールドネックレス', brand: 'VENDOME', imageUrl: 'https://placehold.co/400x400/f8f0ff/888?text=Necklace', price: 3990, productUrl: 'https://www.rakuten.co.jp', category: 'accessory', source: 'rakuten' },
+    { externalId: 'mock-acc-2', name: 'レザーベルト', brand: 'UNIQLO', imageUrl: 'https://placehold.co/400x400/f8f0ff/888?text=Belt', price: 2490, productUrl: 'https://www.rakuten.co.jp', category: 'accessory', source: 'rakuten' },
+    { externalId: 'mock-acc-3', name: 'ウールベレー帽', brand: 'GU', imageUrl: 'https://placehold.co/400x400/f8f0ff/888?text=Hat', price: 1490, productUrl: 'https://www.rakuten.co.jp', category: 'accessory', source: 'rakuten' },
+  ],
+}
+
+interface RakutenApiItem {
+  itemCode: string
+  itemName: string
+  shopName: string
+  mediumImageUrls: Array<{ imageUrl: string }>
+  itemPrice: number
+  itemUrl: string
+}
+
+interface RakutenApiResponse {
+  Items: Array<{ Item: RakutenApiItem }>
+}
+
+export async function searchProducts(category: string): Promise<RakutenProduct[]> {
+  // Fall back to mock data if no API key configured
+  if (!config.rakutenAppId) {
+    console.info(`[rakuten] No RAKUTEN_APP_ID — returning mock data for category: ${category}`)
+    return (MOCK_PRODUCTS[category] ?? MOCK_PRODUCTS.tops).slice(0, PRODUCTS_PER_CATEGORY)
+  }
+
+  const keyword = CATEGORY_KEYWORDS[category] ?? CATEGORY_KEYWORDS.other
+  const params = new URLSearchParams({
+    applicationId: config.rakutenAppId,
+    keyword,
+    hits: String(PRODUCTS_PER_CATEGORY),
+    sort: '-reviewCount',     // popular items first
+    imageFlag: '1',           // only items with images
+    formatVersion: '2',
+  })
+
+  try {
+    const res = await fetch(`${RAKUTEN_SEARCH_URL}?${params}`, {
+      signal: AbortSignal.timeout(10_000),
+    })
+    if (!res.ok) throw new Error(`Rakuten API error: ${res.status}`)
+
+    const json = await res.json() as RakutenApiResponse
+
+    return (json.Items ?? []).map((entry) => {
+      const item = entry.Item
+      return {
+        externalId: item.itemCode,
+        name: item.itemName.slice(0, 200),
+        brand: item.shopName || null,
+        imageUrl: item.mediumImageUrls[0]?.imageUrl ?? '',
+        price: item.itemPrice,
+        productUrl: item.itemUrl,
+        category,
+        source: 'rakuten' as const,
+      }
+    }).filter((p) => p.imageUrl)
+  } catch (err) {
+    console.error(`[rakuten] Search failed for category ${category}:`, err)
+    // Graceful degradation: return mock data on API failure
+    return (MOCK_PRODUCTS[category] ?? MOCK_PRODUCTS.tops).slice(0, PRODUCTS_PER_CATEGORY)
+  }
+}

--- a/apps/api/src/services/rakuten.ts
+++ b/apps/api/src/services/rakuten.ts
@@ -91,7 +91,8 @@ export async function searchProducts(category: string): Promise<RakutenProduct[]
     hits: String(PRODUCTS_PER_CATEGORY),
     sort: '-reviewCount',     // popular items first
     imageFlag: '1',           // only items with images
-    formatVersion: '2',
+    // formatVersion omitted — use default v1 format: Items[].Item (uppercase)
+    // formatVersion=2 changes to Items[].item (lowercase) which breaks the type mapping
   })
 
   try {

--- a/apps/mobile/app/(tabs)/coordinate/[id].tsx
+++ b/apps/mobile/app/(tabs)/coordinate/[id].tsx
@@ -1,0 +1,359 @@
+import { useEffect, useState } from 'react'
+import {
+  View,
+  Text,
+  ScrollView,
+  Image,
+  TouchableOpacity,
+  StyleSheet,
+  Dimensions,
+  ActivityIndicator,
+  FlatList,
+  Linking,
+  SafeAreaView,
+} from 'react-native'
+import { useLocalSearchParams, useRouter } from 'expo-router'
+import { Ionicons } from '@expo/vector-icons'
+import { apiRequest } from '../../../src/lib/api'
+import { useAuth } from '../../../src/contexts/AuthContext'
+
+const { width: screenWidth } = Dimensions.get('window')
+
+const colors = {
+  primary: '#1A1A1A',
+  background: '#FAFAFA',
+  muted: '#F4F4F5',
+  border: '#E4E4E7',
+  mutedText: '#71717A',
+  blue: '#007AFF',
+}
+
+const CATEGORY_LABELS: Record<string, string> = {
+  tops: 'トップス',
+  bottoms: 'ボトムス',
+  outerwear: 'アウター',
+  shoes: 'シューズ',
+  bag: 'バッグ',
+  accessory: 'アクセサリー',
+  other: 'その他',
+}
+
+interface Coordinate {
+  id: string
+  inspirationImageUrl: string
+  description: string | null
+  styleNote: string | null
+  matchScore: number | null
+  isFavorite: boolean
+  itemIds: string[]
+  createdAt: string
+}
+
+interface ProductSuggestion {
+  id: string
+  name: string
+  brand: string | null
+  imageUrl: string
+  price: number
+  productUrl: string
+  category: string | null
+}
+
+export default function CoordinateDetailScreen() {
+  const router = useRouter()
+  const { id } = useLocalSearchParams<{ id: string }>()
+  const { token } = useAuth()
+
+  const [coordinate, setCoordinate] = useState<Coordinate | null>(null)
+  const [isLoadingCoordinate, setIsLoadingCoordinate] = useState(true)
+  const [missingCategories, setMissingCategories] = useState<string[]>([])
+  const [products, setProducts] = useState<ProductSuggestion[]>([])
+  const [isLoadingProducts, setIsLoadingProducts] = useState(true)
+
+  useEffect(() => {
+    async function fetchData() {
+      setIsLoadingCoordinate(true)
+      setIsLoadingProducts(true)
+
+      try {
+        const coordRes = await apiRequest<{ data: Coordinate[] }>('/coordinates', {
+          token: token ?? undefined,
+        })
+        const found = coordRes.data.find((c) => c.id === id) ?? null
+        setCoordinate(found)
+      } catch {
+        setCoordinate(null)
+      } finally {
+        setIsLoadingCoordinate(false)
+      }
+
+      try {
+        const prodRes = await apiRequest<{ data: { missingCategories: string[]; products: ProductSuggestion[] } }>(
+          `/products/coordinates/${id}`,
+          { token: token ?? undefined }
+        )
+        setMissingCategories(prodRes.data.missingCategories)
+        setProducts(prodRes.data.products)
+      } catch {
+        setMissingCategories([])
+        setProducts([])
+      } finally {
+        setIsLoadingProducts(false)
+      }
+    }
+
+    fetchData()
+  }, [id, token])
+
+  function renderProductCard({ item }: { item: ProductSuggestion }) {
+    return (
+      <View style={styles.productCard}>
+        <Image
+          source={{ uri: item.imageUrl }}
+          style={styles.productImage}
+          resizeMode="cover"
+        />
+        <Text style={styles.productName} numberOfLines={2}>
+          {item.name}
+        </Text>
+        {item.brand && (
+          <Text style={styles.productBrand}>{item.brand}</Text>
+        )}
+        <Text style={styles.productPrice}>¥{item.price.toLocaleString('ja-JP')}</Text>
+        <TouchableOpacity
+          style={styles.buyButton}
+          onPress={() => Linking.openURL(item.productUrl)}
+          activeOpacity={0.8}
+        >
+          <Text style={styles.buyButtonText}>購入する</Text>
+        </TouchableOpacity>
+      </View>
+    )
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.navBar}>
+        <TouchableOpacity
+          style={styles.backButton}
+          onPress={() => router.back()}
+          activeOpacity={0.7}
+        >
+          <Ionicons name="chevron-back" size={24} color={colors.primary} />
+        </TouchableOpacity>
+        <Text style={styles.navTitle}>コーデ詳細</Text>
+        <View style={styles.navPlaceholder} />
+      </View>
+
+      {isLoadingCoordinate ? (
+        <View style={styles.centered}>
+          <ActivityIndicator size="large" color={colors.primary} />
+        </View>
+      ) : !coordinate ? (
+        <View style={styles.centered}>
+          <Text style={styles.errorText}>データが見つかりませんでした</Text>
+        </View>
+      ) : (
+        <ScrollView showsVerticalScrollIndicator={false}>
+          <Image
+            source={{ uri: coordinate.inspirationImageUrl }}
+            style={styles.inspirationImage}
+            resizeMode="cover"
+          />
+
+          <View style={styles.content}>
+            {coordinate.matchScore !== null && (
+              <View style={styles.matchBadge}>
+                <Text style={styles.matchBadgeText}>
+                  マッチ度 {Math.round(coordinate.matchScore * 100)}%
+                </Text>
+              </View>
+            )}
+
+            {coordinate.description && (
+              <Text style={styles.description}>{coordinate.description}</Text>
+            )}
+
+            {coordinate.styleNote && (
+              <Text style={styles.styleNote}>{coordinate.styleNote}</Text>
+            )}
+
+            <View style={styles.divider} />
+
+            <Text style={styles.sectionTitle}>不足アイテムを購入する</Text>
+
+            {isLoadingProducts ? (
+              <View style={styles.productsLoading}>
+                <ActivityIndicator size="small" color={colors.primary} />
+              </View>
+            ) : missingCategories.length === 0 ? (
+              <Text style={styles.allCategoriesText}>すべてのカテゴリが揃っています 👍</Text>
+            ) : (
+              missingCategories.map((category) => {
+                const categoryProducts = products.filter((p) => p.category === category)
+                return (
+                  <View key={category}>
+                    <Text style={styles.categoryLabel}>
+                      {CATEGORY_LABELS[category] ?? category}
+                    </Text>
+                    <FlatList
+                      data={categoryProducts}
+                      renderItem={renderProductCard}
+                      keyExtractor={(item) => item.id}
+                      horizontal
+                      showsHorizontalScrollIndicator={false}
+                      contentContainerStyle={styles.productList}
+                    />
+                  </View>
+                )
+              })
+            )}
+          </View>
+        </ScrollView>
+      )}
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  navBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+    backgroundColor: colors.background,
+  },
+  backButton: {
+    width: 36,
+    height: 36,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  navTitle: {
+    fontSize: 17,
+    fontWeight: '700',
+    color: colors.primary,
+  },
+  navPlaceholder: {
+    width: 36,
+  },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 32,
+  },
+  errorText: {
+    fontSize: 15,
+    color: colors.mutedText,
+    textAlign: 'center',
+  },
+  inspirationImage: {
+    width: screenWidth,
+    height: 240,
+  },
+  content: {
+    padding: 16,
+  },
+  matchBadge: {
+    alignSelf: 'flex-start',
+    backgroundColor: colors.primary,
+    borderRadius: 6,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    marginBottom: 12,
+  },
+  matchBadgeText: {
+    color: '#FFFFFF',
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  description: {
+    fontSize: 14,
+    lineHeight: 22,
+    color: colors.primary,
+    marginBottom: 8,
+  },
+  styleNote: {
+    fontSize: 13,
+    color: colors.mutedText,
+    fontStyle: 'italic',
+    marginBottom: 8,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: colors.border,
+    marginVertical: 16,
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: colors.primary,
+    marginBottom: 8,
+  },
+  productsLoading: {
+    paddingVertical: 24,
+    alignItems: 'center',
+  },
+  allCategoriesText: {
+    fontSize: 14,
+    color: colors.mutedText,
+    textAlign: 'center',
+    paddingVertical: 16,
+  },
+  categoryLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: colors.primary,
+    marginTop: 12,
+    marginBottom: 8,
+  },
+  productList: {
+    paddingBottom: 8,
+  },
+  productCard: {
+    width: 140,
+    marginRight: 12,
+  },
+  productImage: {
+    width: 140,
+    height: 140,
+    borderRadius: 8,
+    marginBottom: 6,
+  },
+  productName: {
+    fontSize: 12,
+    color: colors.primary,
+    lineHeight: 16,
+    marginBottom: 2,
+  },
+  productBrand: {
+    fontSize: 11,
+    color: colors.mutedText,
+    marginBottom: 2,
+  },
+  productPrice: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: colors.primary,
+    marginBottom: 6,
+  },
+  buyButton: {
+    backgroundColor: colors.blue,
+    borderRadius: 6,
+    paddingVertical: 6,
+    alignItems: 'center',
+  },
+  buyButtonText: {
+    color: '#FFFFFF',
+    fontSize: 12,
+    fontWeight: '600',
+  },
+})

--- a/apps/mobile/app/(tabs)/coordinate/[id].tsx
+++ b/apps/mobile/app/(tabs)/coordinate/[id].tsx
@@ -71,17 +71,22 @@ export default function CoordinateDetailScreen() {
   const [isLoadingProducts, setIsLoadingProducts] = useState(true)
 
   useEffect(() => {
+    const controller = new AbortController()
+    const { signal } = controller
+
     async function fetchData() {
       setIsLoadingCoordinate(true)
       setIsLoadingProducts(true)
 
       const [coordResult, prodResult] = await Promise.allSettled([
-        apiRequest<{ data: Coordinate }>(`/coordinates/${id}`, { token: token ?? undefined }),
+        apiRequest<{ data: Coordinate }>(`/coordinates/${id}`, { token: token ?? undefined, signal }),
         apiRequest<{ data: { missingCategories: string[]; products: ProductSuggestion[] } }>(
           `/products/coordinates/${id}`,
-          { token: token ?? undefined }
+          { token: token ?? undefined, signal }
         ),
       ])
+
+      if (signal.aborted) return
 
       if (coordResult.status === 'fulfilled') {
         setCoordinate(coordResult.value.data)
@@ -101,6 +106,7 @@ export default function CoordinateDetailScreen() {
     }
 
     fetchData()
+    return () => controller.abort()
   }, [id, token])
 
   function renderProductCard({ item }: { item: ProductSuggestion }) {

--- a/apps/mobile/app/(tabs)/coordinate/[id].tsx
+++ b/apps/mobile/app/(tabs)/coordinate/[id].tsx
@@ -75,31 +75,29 @@ export default function CoordinateDetailScreen() {
       setIsLoadingCoordinate(true)
       setIsLoadingProducts(true)
 
-      try {
-        const coordRes = await apiRequest<{ data: Coordinate[] }>('/coordinates', {
-          token: token ?? undefined,
-        })
-        const found = coordRes.data.find((c) => c.id === id) ?? null
-        setCoordinate(found)
-      } catch {
-        setCoordinate(null)
-      } finally {
-        setIsLoadingCoordinate(false)
-      }
-
-      try {
-        const prodRes = await apiRequest<{ data: { missingCategories: string[]; products: ProductSuggestion[] } }>(
+      const [coordResult, prodResult] = await Promise.allSettled([
+        apiRequest<{ data: Coordinate }>(`/coordinates/${id}`, { token: token ?? undefined }),
+        apiRequest<{ data: { missingCategories: string[]; products: ProductSuggestion[] } }>(
           `/products/coordinates/${id}`,
           { token: token ?? undefined }
-        )
-        setMissingCategories(prodRes.data.missingCategories)
-        setProducts(prodRes.data.products)
-      } catch {
+        ),
+      ])
+
+      if (coordResult.status === 'fulfilled') {
+        setCoordinate(coordResult.value.data)
+      } else {
+        setCoordinate(null)
+      }
+      setIsLoadingCoordinate(false)
+
+      if (prodResult.status === 'fulfilled') {
+        setMissingCategories(prodResult.value.data.missingCategories)
+        setProducts(prodResult.value.data.products)
+      } else {
         setMissingCategories([])
         setProducts([])
-      } finally {
-        setIsLoadingProducts(false)
       }
+      setIsLoadingProducts(false)
     }
 
     fetchData()

--- a/apps/mobile/app/(tabs)/coordinate/index.tsx
+++ b/apps/mobile/app/(tabs)/coordinate/index.tsx
@@ -70,7 +70,7 @@ export default function CoordinateScreen() {
 
   function renderItem({ item }: { item: Coordinate }) {
     return (
-      <TouchableOpacity style={styles.card} activeOpacity={0.8}>
+      <TouchableOpacity style={styles.card} activeOpacity={0.8} onPress={() => router.push({ pathname: '/(tabs)/coordinate/[id]', params: { id: item.id } })}>
         <Image
           source={{ uri: item.inspirationImageUrl }}
           style={styles.cardImage}

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -1,0 +1,28 @@
+{
+  "cli": {
+    "version": ">= 18.0.0"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      }
+    },
+    "preview": {
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      }
+    },
+    "production": {
+      "android": {
+        "buildType": "app-bundle"
+      }
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -16,15 +16,16 @@
     "@cordinate/shared": "workspace:*",
     "@expo/vector-icons": "^14.0.0",
     "expo": "~53.0.0",
-    "expo-router": "~4.0.0",
     "expo-camera": "~16.0.0",
     "expo-image-picker": "~16.0.0",
+    "expo-router": "~4.0.0",
     "expo-secure-store": "~14.0.0",
     "react": "18.3.1",
     "react-native": "0.76.7",
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@expo/ngrok": "^4.1.3",
     "@types/react": "~18.3.12",
     "typescript": "^5.8.2"
   }

--- a/apps/web/postcss.config.mjs
+++ b/apps/web/postcss.config.mjs
@@ -1,0 +1,7 @@
+const config = {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+}
+
+export default config

--- a/apps/web/src/app/coordinate/[id]/page.tsx
+++ b/apps/web/src/app/coordinate/[id]/page.tsx
@@ -1,0 +1,250 @@
+'use client'
+import React from 'react'
+import Link from 'next/link'
+import useSWR from 'swr'
+import { useAuth } from '@/contexts/AuthContext'
+import { apiRequest } from '@/lib/api'
+
+interface Coordinate {
+  id: string
+  inspirationImageUrl: string
+  description: string | null
+  styleNote: string | null
+  matchScore: number | null
+  isFavorite: boolean
+  itemIds: string[]
+  createdAt: string
+}
+
+interface ProductSuggestion {
+  id: string
+  name: string
+  brand: string | null
+  imageUrl: string
+  price: number
+  productUrl: string
+  category: string | null
+}
+
+interface ProductsResponse {
+  missingCategories: string[]
+  products: ProductSuggestion[]
+}
+
+const CATEGORY_LABELS: Record<string, string> = {
+  tops: 'トップス',
+  bottoms: 'ボトムス',
+  outerwear: 'アウター',
+  shoes: 'シューズ',
+  bag: 'バッグ',
+  accessory: 'アクセサリー',
+  other: 'その他',
+}
+
+export default function CoordinateDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}): React.JSX.Element {
+  const { id } = React.use(params)
+  const { accessToken } = useAuth()
+
+  const { data: coordListData, isLoading: coordLoading } = useSWR(
+    accessToken ? '/coordinates' : null,
+    () => apiRequest<{ data: Coordinate[] }>('/coordinates', { token: accessToken! }),
+    { revalidateOnFocus: false }
+  )
+
+  const { data: productsData, isLoading: productsLoading } = useSWR(
+    accessToken ? `/products/coordinates/${id}` : null,
+    () =>
+      apiRequest<{ data: ProductsResponse }>(`/products/coordinates/${id}`, {
+        token: accessToken!,
+      }),
+    { revalidateOnFocus: false }
+  )
+
+  const coord = coordListData?.data.find((c) => c.id === id)
+  const products = productsData?.data
+
+  return (
+    <div
+      className="flex min-h-screen flex-col"
+      style={{ backgroundColor: 'var(--color-background)' }}
+    >
+      {/* Header */}
+      <header
+        className="sticky top-0 z-10 flex items-center gap-3 px-4 py-3 border-b"
+        style={{
+          backgroundColor: 'var(--color-background)',
+          borderColor: 'var(--color-border)',
+        }}
+      >
+        <Link
+          href="/coordinate"
+          className="flex items-center justify-center h-8 w-8 rounded-full transition-colors"
+          style={{
+            backgroundColor: 'var(--color-muted)',
+            color: 'var(--color-foreground)',
+          }}
+          aria-label="戻る"
+        >
+          ←
+        </Link>
+        <h1
+          className="text-xl font-bold tracking-tight"
+          style={{ fontFamily: 'var(--font-serif)' }}
+        >
+          コーデ詳細
+        </h1>
+      </header>
+
+      <main className="flex-1 px-4 py-4 flex flex-col gap-4">
+        {coordLoading && (
+          <div className="flex items-center justify-center py-20">
+            <div
+              className="h-8 w-8 animate-spin rounded-full border-2"
+              style={{ borderColor: 'var(--color-accent)', borderTopColor: 'transparent' }}
+            />
+          </div>
+        )}
+
+        {!coordLoading && coord && (
+          <>
+            {/* Inspiration image */}
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={coord.inspirationImageUrl}
+              alt={coord.description ?? 'コーデ画像'}
+              className="w-full max-h-64 object-cover rounded-xl"
+            />
+
+            {/* Match score badge */}
+            {coord.matchScore != null && (
+              <div className="flex">
+                <span
+                  className="text-sm font-semibold px-3 py-1 rounded-full"
+                  style={{
+                    backgroundColor: 'var(--color-primary)',
+                    color: 'var(--color-primary-foreground)',
+                  }}
+                >
+                  マッチ度 {Math.round(coord.matchScore * 100)}%
+                </span>
+              </div>
+            )}
+
+            {/* Description */}
+            {coord.description && (
+              <p className="text-sm" style={{ color: 'var(--color-foreground)' }}>
+                {coord.description}
+              </p>
+            )}
+
+            {/* Style note */}
+            {coord.styleNote && (
+              <p className="text-sm" style={{ color: 'var(--color-muted-foreground)' }}>
+                {coord.styleNote}
+              </p>
+            )}
+
+            {/* Divider + products section */}
+            <hr style={{ borderColor: 'var(--color-border)' }} />
+            <h2 className="text-base font-semibold" style={{ color: 'var(--color-foreground)' }}>
+              不足アイテムを購入する
+            </h2>
+
+            {productsLoading && (
+              <div className="flex items-center justify-center py-10">
+                <div
+                  className="h-8 w-8 animate-spin rounded-full border-2"
+                  style={{ borderColor: 'var(--color-accent)', borderTopColor: 'transparent' }}
+                />
+              </div>
+            )}
+
+            {!productsLoading && products && (
+              <>
+                {products.missingCategories.length === 0 ? (
+                  <p className="text-sm text-center py-4">
+                    すべてのカテゴリが揃っています 👍
+                  </p>
+                ) : (
+                  <div className="flex flex-col gap-4">
+                    {products.missingCategories.map((cat) => {
+                      const catProducts = products.products.filter((p) => p.category === cat)
+                      return (
+                        <div key={cat} className="flex flex-col gap-2">
+                          {/* Category label */}
+                          <span
+                            className="text-xs font-medium px-2 py-0.5 rounded-full self-start"
+                            style={{
+                              backgroundColor: 'var(--color-muted)',
+                              color: 'var(--color-muted-foreground)',
+                            }}
+                          >
+                            {CATEGORY_LABELS[cat] ?? cat}
+                          </span>
+
+                          {/* Products horizontal scroll */}
+                          <div className="flex flex-row gap-3 overflow-x-auto pb-2">
+                            {catProducts.map((product) => (
+                              <div
+                                key={product.id}
+                                className="w-40 shrink-0 flex flex-col gap-1"
+                              >
+                                {/* eslint-disable-next-line @next/next/no-img-element */}
+                                <img
+                                  src={product.imageUrl}
+                                  alt={product.name}
+                                  className="w-40 h-40 object-cover rounded-lg"
+                                  style={{ backgroundColor: 'var(--color-muted)' }}
+                                />
+                                <p
+                                  className="text-xs line-clamp-2"
+                                  style={{ color: 'var(--color-foreground)' }}
+                                >
+                                  {product.name}
+                                </p>
+                                {product.brand && (
+                                  <p
+                                    className="text-xs"
+                                    style={{ color: 'var(--color-muted-foreground)' }}
+                                  >
+                                    {product.brand}
+                                  </p>
+                                )}
+                                <p
+                                  className="text-xs font-semibold"
+                                  style={{ color: 'var(--color-foreground)' }}
+                                >
+                                  ¥{product.price.toLocaleString('ja-JP')}
+                                </p>
+                                <a
+                                  href={product.productUrl}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="text-xs text-center py-1 rounded-lg font-medium"
+                                  style={{
+                                    backgroundColor: 'var(--color-primary)',
+                                    color: 'var(--color-primary-foreground)',
+                                  }}
+                                >
+                                  購入する
+                                </a>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      )
+                    })}
+                  </div>
+                )}
+              </>
+            )}
+          </>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/apps/web/src/app/coordinate/[id]/page.tsx
+++ b/apps/web/src/app/coordinate/[id]/page.tsx
@@ -49,9 +49,9 @@ export default function CoordinateDetailPage({
   const { id } = React.use(params)
   const { accessToken } = useAuth()
 
-  const { data: coordListData, isLoading: coordLoading } = useSWR(
-    accessToken ? '/coordinates' : null,
-    () => apiRequest<{ data: Coordinate[] }>('/coordinates', { token: accessToken! }),
+  const { data: coordData, isLoading: coordLoading } = useSWR(
+    accessToken ? `/coordinates/${id}` : null,
+    () => apiRequest<{ data: Coordinate }>(`/coordinates/${id}`, { token: accessToken! }),
     { revalidateOnFocus: false }
   )
 
@@ -64,7 +64,7 @@ export default function CoordinateDetailPage({
     { revalidateOnFocus: false }
   )
 
-  const coord = coordListData?.data.find((c) => c.id === id)
+  const coord = coordData?.data
   const products = productsData?.data
 
   return (

--- a/apps/web/src/app/coordinate/[id]/page.tsx
+++ b/apps/web/src/app/coordinate/[id]/page.tsx
@@ -49,7 +49,7 @@ export default function CoordinateDetailPage({
   const { id } = React.use(params)
   const { accessToken } = useAuth()
 
-  const { data: coordData, isLoading: coordLoading } = useSWR(
+  const { data: coordData, isLoading: coordLoading, error: coordError } = useSWR(
     accessToken ? `/coordinates/${id}` : null,
     () => apiRequest<{ data: Coordinate }>(`/coordinates/${id}`, { token: accessToken! }),
     { revalidateOnFocus: false }
@@ -106,6 +106,14 @@ export default function CoordinateDetailPage({
               className="h-8 w-8 animate-spin rounded-full border-2"
               style={{ borderColor: 'var(--color-accent)', borderTopColor: 'transparent' }}
             />
+          </div>
+        )}
+
+        {!coordLoading && (coordError || !coord) && (
+          <div className="flex flex-col items-center justify-center py-20 gap-2 text-center">
+            <p className="text-sm" style={{ color: 'var(--color-muted-foreground)' }}>
+              コーデが見つかりませんでした
+            </p>
           </div>
         )}
 

--- a/apps/web/src/app/coordinate/page.tsx
+++ b/apps/web/src/app/coordinate/page.tsx
@@ -101,8 +101,9 @@ export default function CoordinatePage(): React.JSX.Element {
         {!isLoading && !error && coordinates.length > 0 && (
           <div className="grid grid-cols-2 gap-3">
             {coordinates.map((coord) => (
-              <div
+              <Link
                 key={coord.id}
+                href={`/coordinate/${coord.id}`}
                 className="overflow-hidden rounded-xl border flex flex-col"
                 style={{
                   borderColor: 'var(--color-border)',
@@ -138,7 +139,7 @@ export default function CoordinatePage(): React.JSX.Element {
                     {new Date(coord.createdAt).toLocaleDateString('ja-JP')}
                   </p>
                 </div>
-              </div>
+              </Link>
             ))}
           </div>
         )}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,4 +1,6 @@
 @import "tailwindcss";
+@source "../**/*.{ts,tsx}";
+@source "../../**/*.{ts,tsx}";
 
 :root {
   --color-primary: #1a1a1a;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
         specifier: ^3.24.2
         version: 3.25.76
     devDependencies:
+      '@expo/ngrok':
+        specifier: ^4.1.3
+        version: 4.1.3
       '@types/react':
         specifier: ~18.3.12
         version: 18.3.28
@@ -1499,6 +1502,69 @@ packages:
     peerDependencies:
       react-native: '*'
 
+  '@expo/ngrok-bin-darwin-arm64@2.3.41':
+    resolution: {integrity: sha512-TPf95xp6SkvbRONZjltTOFcCJbmzAH7lrQ36Dv+djrOckWGPVq4HCur48YAeiGDqspmFEmqZ7ykD5c/bDfRFOA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@expo/ngrok-bin-darwin-x64@2.3.41':
+    resolution: {integrity: sha512-29QZHfX4Ec0p0pQF5UrqiP2/Qe7t2rI96o+5b8045VCEl9AEAKHceGuyo+jfUDR4FSQBGFLSDb06xy8ghL3ZYA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@expo/ngrok-bin-freebsd-ia32@2.3.41':
+    resolution: {integrity: sha512-YYXgwNZ+p0aIrwgb+1/RxJbsWhGEzBDBhZulKg1VB7tKDAd2C8uGnbK1rOCuZy013iOUsJDXaj9U5QKc13iIXw==}
+    cpu: [ia32]
+    os: [freebsd]
+
+  '@expo/ngrok-bin-freebsd-x64@2.3.41':
+    resolution: {integrity: sha512-1Ei6K8BB+3etmmBT0tXYC4dyVkJMigT4ELbRTF5jKfw1pblqeXM9Qpf3p8851PTlH142S3bockCeO39rSkOnkg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@expo/ngrok-bin-linux-arm64@2.3.41':
+    resolution: {integrity: sha512-eC8GA/xPcmQJy4h+g2FlkuQB3lf5DjITy8Y6GyydmPYMByjUYAGEXe0brOcP893aalAzRqbNOAjSuAw1lcCLSQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@expo/ngrok-bin-linux-arm@2.3.41':
+    resolution: {integrity: sha512-B6+rW/+tEi7ZrKWQGkRzlwmKo7c1WJhNODFBSgkF/Sj9PmmNhBz67mer91S2+6nNt5pfcwLLd61CjtWfR1LUHQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@expo/ngrok-bin-linux-ia32@2.3.41':
+    resolution: {integrity: sha512-w5Cy31wSz4jYnygEHS7eRizR1yt8s9TX6kHlkjzayIiRTFRb2E1qD2l0/4T2w0LJpBjM5ZFPaaKqsNWgCUIEow==}
+    cpu: [ia32]
+    os: [linux]
+
+  '@expo/ngrok-bin-linux-x64@2.3.41':
+    resolution: {integrity: sha512-LcU3MbYHv7Sn2eFz8Yzo2rXduufOvX1/hILSirwCkH+9G8PYzpwp2TeGqVWuO+EmvtBe6NEYwgdQjJjN6I4L1A==}
+    cpu: [x64]
+    os: [linux]
+
+  '@expo/ngrok-bin-sunos-x64@2.3.41':
+    resolution: {integrity: sha512-bcOj45BLhiV2PayNmLmEVZlFMhEiiGpOr36BXC0XSL+cHUZHd6uNaS28AaZdz95lrRzGpeb0hAF8cuJjo6nq4g==}
+    cpu: [x64]
+    os: [sunos]
+
+  '@expo/ngrok-bin-win32-ia32@2.3.41':
+    resolution: {integrity: sha512-0+vPbKvUA+a9ERgiAknmZCiWA3AnM5c6beI+51LqmjKEM4iAAlDmfXNJ89aAbvZMUtBNwEPHzJHnaM4s2SeBhA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@expo/ngrok-bin-win32-x64@2.3.41':
+    resolution: {integrity: sha512-mncsPRaG462LiYrM8mQT8OYe3/i44m3N/NzUeieYpGi8+pCOo8TIC23kR9P93CVkbM9mmXsy3X6hq91a8FWBdA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@expo/ngrok-bin@2.3.42':
+    resolution: {integrity: sha512-kyhORGwv9XpbPeNIrX6QZ9wDVCDOScyTwxeS+ScNmUqYoZqD9LRmEqF7bpDh5VonTsrXgWrGl7wD2++oSHcaTQ==}
+    hasBin: true
+
+  '@expo/ngrok@4.1.3':
+    resolution: {integrity: sha512-AESYaROGIGKWwWmUyQoUXcbvaUZjmpecC5buArXxYou+RID813F8T0Y5jQ2HUY49mZpYfJiy9oh4VSN37GgrXA==}
+    engines: {node: '>=10.19.0'}
+
   '@expo/osascript@2.4.2':
     resolution: {integrity: sha512-/XP7PSYF2hzOZzqfjgkoWtllyeTN8dW3aM4P6YgKcmmPikKL5FdoyQhti4eh6RK5a5VrUXJTOlTNIpIHsfB5Iw==}
     engines: {node: '>=12'}
@@ -2000,6 +2066,10 @@ packages:
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
 
+  '@sindresorhus/is@4.6.0':
+    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
+    engines: {node: '>=10'}
+
   '@sinonjs/commons@3.0.1':
     resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
 
@@ -2011,6 +2081,10 @@ packages:
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@szmarczak/http-timer@4.0.6':
+    resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
+    engines: {node: '>=10'}
 
   '@tailwindcss/node@4.2.1':
     resolution: {integrity: sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg==}
@@ -2122,6 +2196,9 @@ packages:
   '@types/bcrypt@5.0.2':
     resolution: {integrity: sha512-6atioO8Y75fNcbmj0G7UjI9lXN2pQ/IGJ2FWT4a/btd0Lk9lQalHLKhkgKVZ3r+spnmWUKfbMi1GEe9wyHQfNQ==}
 
+  '@types/cacheable-request@6.0.3':
+    resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
+
   '@types/diff-match-patch@1.0.36':
     resolution: {integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==}
 
@@ -2130,6 +2207,9 @@ packages:
 
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
+
+  '@types/http-cache-semantics@4.2.0':
+    resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
 
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
@@ -2148,6 +2228,9 @@ packages:
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/keyv@3.1.4':
+    resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
 
   '@types/node-forge@1.3.14':
     resolution: {integrity: sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==}
@@ -2171,6 +2254,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/responselike@1.0.3':
+    resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -2682,6 +2768,14 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  cacheable-lookup@5.0.4:
+    resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
+    engines: {node: '>=10.6.0'}
+
+  cacheable-request@7.0.4:
+    resolution: {integrity: sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -2774,6 +2868,9 @@ packages:
   clone-deep@4.0.1:
     resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
     engines: {node: '>=6'}
+
+  clone-response@1.0.3:
+    resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
 
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
@@ -2904,6 +3001,10 @@ packages:
     resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
     engines: {node: '>=0.10'}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -2917,6 +3018,10 @@ packages:
 
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
+
+  defer-to-connect@2.0.1:
+    resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
+    engines: {node: '>=10'}
 
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
@@ -3092,6 +3197,9 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enhanced-resolve@5.20.0:
     resolution: {integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==}
@@ -3586,6 +3694,10 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
@@ -3633,6 +3745,10 @@ packages:
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  got@11.8.6:
+    resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
+    engines: {node: '>=10.19.0'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -3691,9 +3807,16 @@ packages:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  http2-wrapper@1.0.3:
+    resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
+    engines: {node: '>=10.19.0'}
 
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
@@ -4232,6 +4355,10 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lowercase-keys@2.0.0:
+    resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
+    engines: {node: '>=8'}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -4355,6 +4482,14 @@ packages:
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
+
+  mimic-response@1.0.1:
+    resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
+    engines: {node: '>=4'}
+
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
 
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
@@ -4496,6 +4631,10 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  normalize-url@6.1.0:
+    resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
+    engines: {node: '>=10'}
+
   npm-package-arg@11.0.3:
     resolution: {integrity: sha512-sHGJy8sOC1YraBywpzQlIKBE4pBbGbiF95U6Auspzyem956E0+FtDtsx1ZxlOJkQCZ1AFXAY/yuvtFYrOxF+Bw==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -4589,6 +4728,10 @@ packages:
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
+
+  p-cancelable@2.1.1:
+    resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
+    engines: {node: '>=8'}
 
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
@@ -4792,6 +4935,9 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -4809,6 +4955,10 @@ packages:
 
   queue@6.0.2:
     resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
+
+  quick-lru@5.1.1:
+    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
+    engines: {node: '>=10'}
 
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
@@ -4954,6 +5104,9 @@ packages:
     resolution: {integrity: sha512-nYzyjnFcPNGR3lx9lwPPPnuQxv6JWEZd2Ci0u9opN7N5zUEPIhY/GbL3vMGOr2UXwEg9WwSyV9X9Y/kLFgPsOg==}
     engines: {node: '>= 4.0.0'}
 
+  resolve-alpn@1.2.1:
+    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
+
   resolve-from@3.0.0:
     resolution: {integrity: sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==}
     engines: {node: '>=4'}
@@ -4988,6 +5141,9 @@ packages:
     resolution: {integrity: sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==}
     engines: {node: '>= 0.4'}
     hasBin: true
+
+  responselike@2.0.1:
+    resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
 
   restore-cursor@2.0.0:
     resolution: {integrity: sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==}
@@ -5560,6 +5716,11 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
+  uuid@3.4.0:
+    resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
+    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    hasBin: true
+
   uuid@7.0.3:
     resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
     hasBin: true
@@ -5727,6 +5888,10 @@ packages:
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
+
+  yaml@1.10.2:
+    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
+    engines: {node: '>= 6'}
 
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
@@ -7236,6 +7401,60 @@ snapshots:
     dependencies:
       react-native: 0.76.7(@babel/core@7.29.0)(@babel/preset-env@7.29.0(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)
 
+  '@expo/ngrok-bin-darwin-arm64@2.3.41':
+    optional: true
+
+  '@expo/ngrok-bin-darwin-x64@2.3.41':
+    optional: true
+
+  '@expo/ngrok-bin-freebsd-ia32@2.3.41':
+    optional: true
+
+  '@expo/ngrok-bin-freebsd-x64@2.3.41':
+    optional: true
+
+  '@expo/ngrok-bin-linux-arm64@2.3.41':
+    optional: true
+
+  '@expo/ngrok-bin-linux-arm@2.3.41':
+    optional: true
+
+  '@expo/ngrok-bin-linux-ia32@2.3.41':
+    optional: true
+
+  '@expo/ngrok-bin-linux-x64@2.3.41':
+    optional: true
+
+  '@expo/ngrok-bin-sunos-x64@2.3.41':
+    optional: true
+
+  '@expo/ngrok-bin-win32-ia32@2.3.41':
+    optional: true
+
+  '@expo/ngrok-bin-win32-x64@2.3.41':
+    optional: true
+
+  '@expo/ngrok-bin@2.3.42':
+    optionalDependencies:
+      '@expo/ngrok-bin-darwin-arm64': 2.3.41
+      '@expo/ngrok-bin-darwin-x64': 2.3.41
+      '@expo/ngrok-bin-freebsd-ia32': 2.3.41
+      '@expo/ngrok-bin-freebsd-x64': 2.3.41
+      '@expo/ngrok-bin-linux-arm': 2.3.41
+      '@expo/ngrok-bin-linux-arm64': 2.3.41
+      '@expo/ngrok-bin-linux-ia32': 2.3.41
+      '@expo/ngrok-bin-linux-x64': 2.3.41
+      '@expo/ngrok-bin-sunos-x64': 2.3.41
+      '@expo/ngrok-bin-win32-ia32': 2.3.41
+      '@expo/ngrok-bin-win32-x64': 2.3.41
+
+  '@expo/ngrok@4.1.3':
+    dependencies:
+      '@expo/ngrok-bin': 2.3.42
+      got: 11.8.6
+      uuid: 3.4.0
+      yaml: 1.10.2
+
   '@expo/osascript@2.4.2':
     dependencies:
       '@expo/spawn-async': 1.7.2
@@ -7890,6 +8109,8 @@ snapshots:
 
   '@sinclair/typebox@0.27.10': {}
 
+  '@sindresorhus/is@4.6.0': {}
+
   '@sinonjs/commons@3.0.1':
     dependencies:
       type-detect: 4.0.8
@@ -7903,6 +8124,10 @@ snapshots:
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
+
+  '@szmarczak/http-timer@4.0.6':
+    dependencies:
+      defer-to-connect: 2.0.1
 
   '@tailwindcss/node@4.2.1':
     dependencies:
@@ -8003,6 +8228,13 @@ snapshots:
     dependencies:
       '@types/node': 22.19.15
 
+  '@types/cacheable-request@6.0.3':
+    dependencies:
+      '@types/http-cache-semantics': 4.2.0
+      '@types/keyv': 3.1.4
+      '@types/node': 22.19.15
+      '@types/responselike': 1.0.3
+
   '@types/diff-match-patch@1.0.36': {}
 
   '@types/estree@1.0.8': {}
@@ -8010,6 +8242,8 @@ snapshots:
   '@types/graceful-fs@4.1.9':
     dependencies:
       '@types/node': 22.19.15
+
+  '@types/http-cache-semantics@4.2.0': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -8026,6 +8260,10 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
+
+  '@types/keyv@3.1.4':
+    dependencies:
+      '@types/node': 22.19.15
 
   '@types/node-forge@1.3.14':
     dependencies:
@@ -8055,6 +8293,10 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/responselike@1.0.3':
+    dependencies:
+      '@types/node': 22.19.15
 
   '@types/stack-utils@2.0.3': {}
 
@@ -8633,6 +8875,18 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  cacheable-lookup@5.0.4: {}
+
+  cacheable-request@7.0.4:
+    dependencies:
+      clone-response: 1.0.3
+      get-stream: 5.2.0
+      http-cache-semantics: 4.2.0
+      keyv: 4.5.4
+      lowercase-keys: 2.0.0
+      normalize-url: 6.1.0
+      responselike: 2.0.1
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -8728,6 +8982,10 @@ snapshots:
       is-plain-object: 2.0.4
       kind-of: 6.0.3
       shallow-clone: 3.0.1
+
+  clone-response@1.0.3:
+    dependencies:
+      mimic-response: 1.0.1
 
   clone@1.0.4: {}
 
@@ -8851,6 +9109,10 @@ snapshots:
 
   decode-uri-component@0.2.2: {}
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
@@ -8860,6 +9122,8 @@ snapshots:
   defaults@1.0.4:
     dependencies:
       clone: 1.0.4
+
+  defer-to-connect@2.0.1: {}
 
   define-data-property@1.1.4:
     dependencies:
@@ -8937,6 +9201,10 @@ snapshots:
   encodeurl@1.0.2: {}
 
   encodeurl@2.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enhanced-resolve@5.20.0:
     dependencies:
@@ -9684,6 +9952,10 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.4
+
   get-stream@6.0.1: {}
 
   get-symbol-description@1.1.0:
@@ -9735,6 +10007,20 @@ snapshots:
 
   gopd@1.2.0: {}
 
+  got@11.8.6:
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      '@szmarczak/http-timer': 4.0.6
+      '@types/cacheable-request': 6.0.3
+      '@types/responselike': 1.0.3
+      cacheable-lookup: 5.0.4
+      cacheable-request: 7.0.4
+      decompress-response: 6.0.0
+      http2-wrapper: 1.0.3
+      lowercase-keys: 2.0.0
+      p-cancelable: 2.1.1
+      responselike: 2.0.1
+
   graceful-fs@4.2.11: {}
 
   has-bigints@1.1.0: {}
@@ -9781,6 +10067,8 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
 
+  http-cache-semantics@4.2.0: {}
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -9788,6 +10076,11 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  http2-wrapper@1.0.3:
+    dependencies:
+      quick-lru: 5.1.1
+      resolve-alpn: 1.2.1
 
   https-proxy-agent@5.0.1:
     dependencies:
@@ -10312,6 +10605,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  lowercase-keys@2.0.0: {}
+
   lru-cache@10.4.3: {}
 
   lru-cache@5.1.1:
@@ -10536,6 +10831,10 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
+  mimic-response@1.0.1: {}
+
+  mimic-response@3.1.0: {}
+
   minimatch@10.2.4:
     dependencies:
       brace-expansion: 5.0.4
@@ -10651,6 +10950,8 @@ snapshots:
       abbrev: 1.1.1
 
   normalize-path@3.0.0: {}
+
+  normalize-url@6.1.0: {}
 
   npm-package-arg@11.0.3:
     dependencies:
@@ -10774,6 +11075,8 @@ snapshots:
       get-intrinsic: 1.3.0
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
+
+  p-cancelable@2.1.1: {}
 
   p-limit@2.3.0:
     dependencies:
@@ -10949,6 +11252,11 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   punycode@2.3.1: {}
 
   qrcode-terminal@0.11.0: {}
@@ -10965,6 +11273,8 @@ snapshots:
   queue@6.0.2:
     dependencies:
       inherits: 2.0.4
+
+  quick-lru@5.1.1: {}
 
   range-parser@1.2.1: {}
 
@@ -11172,6 +11482,8 @@ snapshots:
       rc: 1.2.8
       resolve: 1.7.1
 
+  resolve-alpn@1.2.1: {}
+
   resolve-from@3.0.0: {}
 
   resolve-from@4.0.0: {}
@@ -11202,6 +11514,10 @@ snapshots:
       object-keys: 1.1.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  responselike@2.0.1:
+    dependencies:
+      lowercase-keys: 2.0.0
 
   restore-cursor@2.0.0:
     dependencies:
@@ -11837,6 +12153,8 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
+  uuid@3.4.0: {}
+
   uuid@7.0.3: {}
 
   validate-npm-package-name@5.0.1: {}
@@ -11987,6 +12305,8 @@ snapshots:
   yallist@4.0.0: {}
 
   yallist@5.0.0: {}
+
+  yaml@1.10.2: {}
 
   yargs-parser@21.1.1: {}
 


### PR DESCRIPTION
## 概要

コーデ提案で使用されなかったカテゴリを「不足アイテム」として検出し、楽天市場APIから購入候補商品を提案する機能を実装。

## 実装内容

### バックエンド (Issue #23)

**`services/rakuten.ts`** — 楽天市場API連携
- カテゴリ（tops/bottoms/outerwear/shoes/bag/accessory）別のキーワードで商品検索
- `RAKUTEN_APP_ID` 未設定時はモックデータで動作（dev/CI環境で安全に動く）
- 10秒 AbortSignal タイムアウト + API障害時もモックにフォールバック

**`routes/product.ts`** — 全面書き直し
- `GET /products/coordinates/:coordinateId`
  1. userId所有権チェック（404 if not owned）
  2. `productSuggestions` テーブルにキャッシュがあれば即返却
  3. coordinate の `itemIds` → 使用カテゴリ集計 → 不足カテゴリ特定
  4. 最大3カテゴリをParallel fetchして `productSuggestions` にキャッシュ保存
  5. `{ missingCategories, products }` を返却
- `GET /products/search` — カテゴリ指定の汎用商品検索

### Web (Issue #24)

**`/coordinate/[id]/page.tsx`** — コーデ詳細画面（新規）
- 参考画像・マッチ度バッジ・説明・styleNote
- 「不足アイテムを購入する」セクション：SWRで商品フェッチ
- カテゴリ別横スクロール商品カード（画像・商品名・ブランド・¥価格・購入リンク）
- 不足なし時は「すべてのカテゴリが揃っています 👍」

**`/coordinate/page.tsx`** — 一覧カードを `<Link>` でラップ（詳細への遷移）

### Mobile (Issue #25)

**`coordinate/[id].tsx`** — コーデ詳細画面（新規）
- ScrollView + NavBar + 参考画像（全幅）
- カテゴリ別横スクロール FlatList（`horizontal`）
- `Linking.openURL` で購入ページへ

**`coordinate/index.tsx`** — カードタップで詳細へ遷移

## Test plan
- [ ] クローゼットにtops・bottomsを持つユーザーがコーデを保存 → 詳細画面でouterwear等の不足アイテム商品が表示される
- [ ] 2回目に詳細画面を開く → productSuggestionsキャッシュから返却される（DB INSERT なし）
- [ ] `RAKUTEN_APP_ID` 未設定でもモック商品が表示される
- [ ] 商品の「購入する」リンクが新タブ（Web）/ Linking.openURL（Mobile）で開く
- [ ] 全カテゴリが揃ったコーデ → 「すべてのカテゴリが揃っています 👍」表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)